### PR TITLE
feat(core) Center carousel images with bootstrap class; close #35

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -17,7 +17,3 @@ body {
     padding-bottom: 175px;
   }
 }
-
-img {
-  margin-left: 3%;
-}

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     <!-- Wrapper for slides -->
     <div class="carousel-inner" role="listbox">
       <div class="item active">
-        <img src="https://placehold.it/1200x400?text=IMAGE" alt="Image">
+        <img class="img-responsive center-block" src="//placehold.it/1200x400?text=IMAGE" alt="Image">
         <div class="carousel-caption">
           <h3>Sell $</h3>
           <p>Money Money.</p>
@@ -59,7 +59,7 @@
       </div>
 
       <div class="item">
-        <img src="https://placehold.it/1200x400?text=Another Image Maybe" alt="Image">
+        <img class="img-responsive center-block" src="//placehold.it/1200x400?text=Another Image Maybe" alt="Image">
         <div class="carousel-caption">
           <h3>More Sell $</h3>
           <p>Lorem ipsum...</p>


### PR DESCRIPTION
To keep this working, each image included in the carousel needs to have the class="img-responsive center-block"
